### PR TITLE
Add lombok @SneakyThrows to tests

### DIFF
--- a/src/test/java/com/ghostframe/postmandoc/PostmanCollectionFactoryTest.java
+++ b/src/test/java/com/ghostframe/postmandoc/PostmanCollectionFactoryTest.java
@@ -1,19 +1,21 @@
 package com.ghostframe.postmandoc;
 
 import com.ghostframe.postmandoc.postman.PostmanCollectionFactory;
-import java.io.File;
-import java.io.IOException;
-import static org.assertj.core.api.Java6Assertions.contentOf;
-import org.json.JSONException;
+import lombok.SneakyThrows;
 import org.junit.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.skyscreamer.jsonassert.JSONCompareMode;
 import org.springframework.core.io.ClassPathResource;
 
+import java.io.File;
+
+import static org.assertj.core.api.Java6Assertions.contentOf;
+
 public class PostmanCollectionFactoryTest {
 
     @Test
-    public void fromSnippetsFolder_withSubfolderPerTestClassAndSubfolderPerTestCaseInCamelCase_generatesExpectedCollection() throws IOException, JSONException {
+    @SneakyThrows
+    public void fromSnippetsFolder_withSubfolderPerTestClassAndSubfolderPerTestCaseInCamelCase_generatesExpectedCollection() {
         File snippetsFolder = new ClassPathResource("folder-per-test-class/generated-snippets-camel-case/").getFile();
         String expectedJson = contentOf(new ClassPathResource("folder-per-test-class/postman_collection.json").getFile());
         String collectionJson = PostmanCollectionFactory.fromSnippetsFolder("rest-docs-sample", snippetsFolder);
@@ -21,7 +23,8 @@ public class PostmanCollectionFactoryTest {
     }
 
     @Test
-    public void fromSnippetsFolder_withSubfolderPerTestClassAndSubfolderPerTestCaseInKebabCase_generatesExpectedCollection() throws IOException, JSONException {
+    @SneakyThrows
+    public void fromSnippetsFolder_withSubfolderPerTestClassAndSubfolderPerTestCaseInKebabCase_generatesExpectedCollection() {
         File snippetsFolder = new ClassPathResource("folder-per-test-class/generated-snippets-kebab-case/").getFile();
         String expectedJson = contentOf(new ClassPathResource("folder-per-test-class/postman_collection.json").getFile());
         String collectionJson = PostmanCollectionFactory.fromSnippetsFolder("rest-docs-sample", snippetsFolder);
@@ -29,7 +32,8 @@ public class PostmanCollectionFactoryTest {
     }
 
     @Test
-    public void fromSnippetsFolder_withSubfolderPerTestClassAndSubfolderPerTestCaseInSnakeCase_generatesExpectedCollection() throws IOException, JSONException {
+    @SneakyThrows
+    public void fromSnippetsFolder_withSubfolderPerTestClassAndSubfolderPerTestCaseInSnakeCase_generatesExpectedCollection() {
         File snippetsFolder = new ClassPathResource("folder-per-test-class/generated-snippets-snake-case/").getFile();
         String expectedJson = contentOf(new ClassPathResource("folder-per-test-class/postman_collection.json").getFile());
         String collectionJson = PostmanCollectionFactory.fromSnippetsFolder("rest-docs-sample", snippetsFolder);
@@ -37,7 +41,8 @@ public class PostmanCollectionFactoryTest {
     }
 
     @Test
-    public void fromSnippetsFolder_withSubfolderPerTestCaseInCamelCase_generatesExpectedCollection() throws IOException, JSONException {
+    @SneakyThrows
+    public void fromSnippetsFolder_withSubfolderPerTestCaseInCamelCase_generatesExpectedCollection() {
         File snippetsFolder = new ClassPathResource("folder-per-test-case/generated-snippets-camel-case/").getFile();
         String expectedJson = contentOf(new ClassPathResource("folder-per-test-case/postman_collection.json").getFile());
         String collectionJson = PostmanCollectionFactory.fromSnippetsFolder("rest-docs-sample", snippetsFolder);


### PR DESCRIPTION
Improves readability and avoid method signature throwing when the context is controlled by the developer